### PR TITLE
Fixed fonts.c files include issue

### DIFF
--- a/Utilities/STM32F769I-Discovery/stm32f769i_discovery_lcd.c
+++ b/Utilities/STM32F769I-Discovery/stm32f769i_discovery_lcd.c
@@ -93,11 +93,6 @@ EndDependencies */
 /* Includes ------------------------------------------------------------------*/
 #include "stm32f769i_discovery_lcd.h"
 #include "../Fonts/fonts.h"
-#include "../Fonts/font24.c"
-#include "../Fonts/font20.c"
-#include "../Fonts/font16.c"
-#include "../Fonts/font12.c"
-#include "../Fonts/font8.c"
 
 /** @addtogroup BSP
   * @{


### PR DESCRIPTION
Removed the inclusion of fonts.c source files from stm32f769i_discovery_lcd.c file as they causes multiple definition error