### PR TITLE
Update GH actions dependency

### DIFF
--- a/.github/workflows/stm32_port.yml
+++ b/.github/workflows/stm32_port.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: arm-none-eabi-gcc
-      uses: carlosperate/arm-none-eabi-gcc-action@v1.3.0
+      uses: carlosperate/arm-none-eabi-gcc-action@v1.12.0
       with:
         release: '10-2020-q4' # The arm-none-eabi-gcc release to use.
     - name: Update submodules

--- a/.github/workflows/stm32_port.yml
+++ b/.github/workflows/stm32_port.yml
@@ -21,7 +21,7 @@ jobs:
       run: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
     - name: Build
       run: cmake --build build
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v5
       with:
         name: lv_stm32f769.bin
         path: build/lv_stm32f769.bin


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the stm32_port workflow to use arm-none-eabi-gcc-action v1.12.0 and actions/upload-artifact v5 for uploading lv_stm32f769.bin. Aligns with latest GitHub Actions and avoids deprecation issues.

<sup>Written for commit d6461f21c86a49dd15383d9752d900aeab397089. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

